### PR TITLE
Testing infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "iojs"
+before_install:
+  - cd libraries/eddystone-advertising-library

--- a/libraries/eddystone-advertising-library/.gitignore
+++ b/libraries/eddystone-advertising-library/.gitignore
@@ -4,3 +4,7 @@
 # emacs
 *~
 \#*\#
+
+bower_components
+node_modules
+npm-debug.log

--- a/libraries/eddystone-advertising-library/.jshintrc
+++ b/libraries/eddystone-advertising-library/.jshintrc
@@ -1,0 +1,9 @@
+{
+  "indent"  : 2,         // Number of spaces to use for indentation
+  "quotmark": "single",  // Require single quotes
+  "varstmt" : true,      // Disallow any var statements. Only 'let' and 'const' are allowed
+  "esnext"  : true,      // Allow ES6 syntax
+  "browser" : true,      // Web Browser (window, document, etc)
+  "devel"   : false,     // Development/debugging (alert, confirm, etc)
+  "mocha"   : true       // Mocha
+}

--- a/libraries/eddystone-advertising-library/eddystone-advertising.js
+++ b/libraries/eddystone-advertising-library/eddystone-advertising.js
@@ -1,0 +1,8 @@
+(() => {
+  'use strict';
+
+  class Eddystone {
+  }
+
+  window.eddystone = new Eddystone();
+})();

--- a/libraries/eddystone-advertising-library/gulpfile.js
+++ b/libraries/eddystone-advertising-library/gulpfile.js
@@ -1,0 +1,51 @@
+// jshint node: true
+
+// Ignore vars in require statements
+// jshint ignore:start
+var gulp = require('gulp');
+var concat = require('gulp-concat');
+var mocha = require('gulp-mocha');
+var jshint = require('gulp-jshint');
+var david = require('gulp-david');
+
+var del = require('del');
+// jshint ignore:end
+
+
+gulp.task('default', () => {
+});
+
+gulp.task('test', [
+  'test:dependencies',
+  'test:style',
+  'test:chrome-os',
+  'clean']
+);
+
+gulp.task('test:dependencies', () => {
+  return gulp.src('package.json')
+             .pipe(david({error404: true}))
+             .pipe(david.reporter);
+});
+
+gulp.task('test:style', () => {
+  return gulp.src(['eddystone-advertising.js', 'gulpfile.js','test/*.js',
+                   'test/**/*.js'])
+             .pipe(jshint())
+             .pipe(jshint.reporter('jshint-stylish'))
+             .pipe(jshint.reporter('fail'));
+});
+
+// TODO: Maybe use browserify instead of concatenating to test.
+gulp.task('test:chrome-os', () => {
+  return gulp.src(['test/setup/chrome-os.js',
+                   'test/eddystone-tests.js',
+                   'eddystone-advertising.js'])
+             .pipe(concat('chrome-os-tests.js'))
+             .pipe(gulp.dest('./temp/'))
+             .pipe(mocha({reporter: 'spec'}));
+});
+
+gulp.task('clean', ['test:chrome-os'], cb => {
+  del('temp/', cb);
+});

--- a/libraries/eddystone-advertising-library/package.json
+++ b/libraries/eddystone-advertising-library/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "eddystone-advertising-library",
+  "version": "0.3.0",
+  "description": "A library to easily broadcast valid Eddystone advertisements.",
+  "main": "eddystone-advertising.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "iojs --harmony_arrow_functions `which gulp` test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/google/eddystone.git"
+  },
+  "keywords": [
+    "eddystone",
+    "ble",
+    "chrome-app"
+  ],
+  "author": "Giovanni Ortuño Urquidi <gd.ortuno@gmail.com>",
+  "contributors": [
+    "Jeffrey Yasskin <jyasskin@chromium.org>"
+  ],
+  "license": {
+    "type": "Apache-2.0",
+    "url": "https://github.com/google/eddystone/blob/master/LICENSE"
+  },
+  "bugs": {
+    "url": "https://github.com/google/eddystone/issues"
+  },
+  "homepage": "https://github.com/google/eddystone/tree/master/libraries/eddystone-advertising-library#readme",
+  "devDependencies": {
+    "bower": "^1.4.1",
+    "chai": "^3.2.0",
+    "del": "^1.2.1",
+    "gulp": "^3.9.0",
+    "gulp-concat": "^2.6.0",
+    "gulp-david": "^0.2.3",
+    "gulp-jshint": "^1.11.2",
+    "gulp-mocha": "^2.1.3",
+    "jshint-stylish": "^2.0.1",
+    "mocha": "^2.2.5"
+  }
+}

--- a/libraries/eddystone-advertising-library/test/eddystone-tests.js
+++ b/libraries/eddystone-advertising-library/test/eddystone-tests.js
@@ -1,0 +1,20 @@
+// jshint node: true
+// We need this so chai expect's don't throw an error.
+// jshint expr: true
+
+// Ignore vars in require statements
+// jshint ignore:start
+var chai = require('chai');
+var expect = chai.expect;
+// jshint ignore:end
+
+describe('Eddystone', () => {
+  describe('global', () => {
+    it('eddystone should exist in window', () => {
+      expect(window).to.have.property('eddystone');
+    });
+    it('Eddystone class shouldn\'t be global', () => {
+      expect(typeof Eddystone).to.equal('undefined');
+    });
+  });
+});

--- a/libraries/eddystone-advertising-library/test/setup/chrome-os.js
+++ b/libraries/eddystone-advertising-library/test/setup/chrome-os.js
@@ -1,0 +1,2 @@
+// Since we are simulating a browser:
+var window = {}; // jshint ignore: line


### PR DESCRIPTION
We use:

* IO.js because node.js doesn't support classes and arrow functions.
* Mocha for running tests
* Chai for asserting (we will probably need to add 'chai as promised' later on)
* JsHint to check the syntax and disallow js nastiness
* jshint-stylish is the jshint reporter
* Gulp for running all our tests and CI
* Travis CI for continuos integration
* gulp-concat to generate testing files.
* del to delete testing files
* gulp-david to test dependencies are present and up to date.
* gulp-jshint and gulp-mocha to hook up jshint and mocha to gulp

The basic idea is that we concatenate the setup script (in the case of chrome os this is where we will mock the API and window), the library and the tests and then we run the tests from that new file.