### PR TITLE
Add ChromeOS API wrapper

### DIFF
--- a/libraries/eddystone-advertising-library/eddystone-advertising.md
+++ b/libraries/eddystone-advertising-library/eddystone-advertising.md
@@ -1,3 +1,20 @@
+## Classes
+<dl>
+<dt><a href="#EddystoneURL">EddystoneURL</a></dt>
+<dd><p>This class provides helper functions that relate to Eddystone-URL.
+      <a href="https://github.com/google/eddystone/tree/master/eddystone-url">https://github.com/google/eddystone/tree/master/eddystone-url</a></p>
+</dd>
+<dt><a href="#EddystoneAdvertisement">EddystoneAdvertisement</a></dt>
+<dd><p>This is the object that holds the information about the registered BLE
+     Advertisement.</p>
+</dd>
+</dl>
+## Typedefs
+<dl>
+<dt><a href="#EddystoneAdvertisementOptions">EddystoneAdvertisementOptions</a> : <code>Object</code></dt>
+<dd><p>Object that contains the characteristics of the package to adverstise.</p>
+</dd>
+</dl>
 <a name="EddystoneURL"></a>
 ## EddystoneURL
 This class provides helper functions that relate to Eddystone-URL.
@@ -55,4 +72,61 @@ Encodes the given string using the encoding defined in the Eddystone-URL
 | Param | Type | Description |
 | --- | --- | --- |
 | url | <code>string</code> | The url to encode. |
+
+<a name="EddystoneAdvertisement"></a>
+## EddystoneAdvertisement
+This is the object that holds the information about the registered BLE
+     Advertisement.
+
+**Kind**: global class  
+
+* [EddystoneAdvertisement](#EddystoneAdvertisement)
+  * [new EddystoneAdvertisement(id, options)](#new_EddystoneAdvertisement_new)
+  * [.id](#EddystoneAdvertisement+id) : <code>number</code>
+  * [.type](#EddystoneAdvertisement+type) : <code>string</code>
+  * [.url?](#EddystoneAdvertisement+url?) : <code>string</code>
+  * [.txPower?](#EddystoneAdvertisement+txPower?) : <code>number</code>
+
+<a name="new_EddystoneAdvertisement_new"></a>
+### new EddystoneAdvertisement(id, options)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| id | <code>number</code> | Unique between browser restarts |
+| options | <code>[EddystoneAdvertisementOptions](#EddystoneAdvertisementOptions)</code> | The options used when        creating the advertisement. |
+
+<a name="EddystoneAdvertisement+id"></a>
+### eddystoneAdvertisement.id : <code>number</code>
+The ID of this advertisment.
+
+**Kind**: instance property of <code>[EddystoneAdvertisement](#EddystoneAdvertisement)</code>  
+<a name="EddystoneAdvertisement+type"></a>
+### eddystoneAdvertisement.type : <code>string</code>
+The Eddystone Type
+
+**Kind**: instance property of <code>[EddystoneAdvertisement](#EddystoneAdvertisement)</code>  
+<a name="EddystoneAdvertisement+url?"></a>
+### eddystoneAdvertisement.url? : <code>string</code>
+URL being advertised.
+         Only present if `type === 'url'`.
+
+**Kind**: instance property of <code>[EddystoneAdvertisement](#EddystoneAdvertisement)</code>  
+<a name="EddystoneAdvertisement+txPower?"></a>
+### eddystoneAdvertisement.txPower? : <code>number</code>
+Tx Power included in
+         the advertisement. Only present if `type === 'url'`.
+
+**Kind**: instance property of <code>[EddystoneAdvertisement](#EddystoneAdvertisement)</code>  
+<a name="EddystoneAdvertisementOptions"></a>
+## EddystoneAdvertisementOptions : <code>Object</code>
+Object that contains the characteristics of the package to adverstise.
+
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| type | <code>EddystoneType</code> | Type of Eddystone. |
+| url? | <code>string</code> | The URL to advertise |
+| txPower? | <code>number</code> | The Tx Power to advertise |
 

--- a/libraries/eddystone-advertising-library/gulpfile.js
+++ b/libraries/eddystone-advertising-library/gulpfile.js
@@ -58,13 +58,18 @@ gulp.task('test:style', () => {
 
 // TODO: Maybe use browserify instead of concatenating to test.
 gulp.task('test:chrome-os', () => {
-  return gulp.src(['test/setup/chrome-os.js',
-                   'test/eddystone-tests.js',
-                   'test/eddystone-url-tests.js',
-                   'eddystone-advertising.js'])
-             .pipe(concat('chrome-os-tests.js'))
-             .pipe(gulp.dest('./temp/'))
-             .pipe(mocha({reporter: 'spec'}));
+  return gulp.src([
+    // Setup
+    'test/setup/chrome-os.js',
+    // Library
+    'eddystone-advertising.js',
+    // Tests
+    'test/eddystone-tests.js',
+    'test/eddystone-url-tests.js',
+    'test/eddystone-chrome-os-tests.js'
+  ]).pipe(concat('chrome-os-tests.js'))
+    .pipe(gulp.dest('./temp/'))
+    .pipe(mocha({reporter: 'spec'}));
 });
 
 gulp.task('clean', ['test:chrome-os'], cb => {

--- a/libraries/eddystone-advertising-library/package.json
+++ b/libraries/eddystone-advertising-library/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "bower": "^1.4.1",
     "chai": "^3.2.0",
+    "chai-as-promised": "^5.1.0",
     "del": "^1.2.1",
     "gulp": "^3.9.0",
     "gulp-concat": "^2.6.0",
@@ -45,6 +46,7 @@
     "gulp-rename": "^1.2.2",
     "jshint-stylish": "^2.0.1",
     "mocha": "^2.2.5",
+    "sinon": "^1.16.1",
     "text-encoding": "^0.5.2"
   }
 }

--- a/libraries/eddystone-advertising-library/test/eddystone-chrome-os-tests.js
+++ b/libraries/eddystone-advertising-library/test/eddystone-chrome-os-tests.js
@@ -1,0 +1,118 @@
+// jshint node: true
+// We need this so chai expect's don't throw an error.
+// jshint expr: true
+
+// Ignore vars in require statements
+// jshint ignore:start
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+var expect = chai.expect;
+// jshint ignore:end
+
+describe('EddystoneChromeOS', () => {
+  describe('global', () => {
+    it('EddystoneChromeOS should be global', () => {
+      expect(typeof EddystoneChromeOS).to.not.equal('undefined');
+    });
+  });
+  describe('constructAdvertisement()', () => {
+    it('Unsupported frame type', () => {
+        expect(() => EddystoneChromeOS._constructAdvertisement({type: 'url'}))
+                                      .not.to.throw(/Unsupported Frame Type/);
+        expect(() => EddystoneChromeOS._constructAdvertisement({type: 'uid'}))
+                                      .to.throw(Error, /Unsupported Frame Type/);
+        expect(() => EddystoneChromeOS._constructAdvertisement({type: 'tlm'}))
+                                      .to.throw(Error, /Unsupported Frame Type/);
+        expect(() => EddystoneChromeOS._constructAdvertisement({}))
+                                      .to.throw(Error, /Unsupported Frame Type/);
+    });
+    describe('Eddystone-URL', () => {
+      'use strict';
+      let url = 'https://www.example.com';
+      let tx_power = -10;
+      it('Valid URL and Tx Power', () => {
+        expect(EddystoneChromeOS._constructAdvertisement({
+          type: 'url',
+          url: url,
+          txPower: tx_power
+        })).to.eql({
+          type: 'broadcast',
+          serviceUuids: ['FEAA'],
+          serviceData: [{
+            uuid: 'FEAA',
+            data: EddystoneURL.constructServiceData(url, tx_power)
+          }]
+        });
+      });
+      it('Valid URL, valid Tx Power', () => {
+        expect(() => EddystoneChromeOS._constructAdvertisement({
+          type: 'url',
+          url: url,
+          txPower: -101
+        })).to.throw(Error, /Invalid Tx Power value/);
+      });
+      it('Invalid URL, invalid Tx Power', () => {
+        expect(() => EddystoneChromeOS._constructAdvertisement({
+          type: 'url',
+          url: 'INVALID',
+          txPower: tx_power
+        })).to.throw(Error, /Scheme/);
+        expect(() => EddystoneChromeOS._constructAdvertisement({
+          type: 'url',
+          url: 'http://' + String.fromCharCode(0x0),
+          txPower: tx_power
+        })).to.throw(Error, /character/);
+      });
+      it('Invalid URL, invalid Tx Power', () => {
+        expect(() => EddystoneChromeOS._constructAdvertisement({
+          type: 'url',
+          url: 'INVALID',
+          txPower: -101
+        })).to.throw(Error);
+        expect(() => EddystoneChromeOS._constructAdvertisement({
+          type: 'url',
+          url: 'http://' + String.fromCharCode(0x0),
+          txPower: -101
+        })).to.throw(Error);
+      });
+    });
+  });
+  describe('registerAdvertisement()', () => {
+    'use strict';
+    let valid_options = {
+      type: 'url',
+      url: 'https://www.example.com',
+      txPower: -10
+    };
+
+    // Hooks
+    afterEach(() => cleanChromeMock());
+
+    it('Registering fails', () => {
+      mockRegisteringFailsWithMessage();
+      return expect(EddystoneChromeOS.registerAdvertisement(valid_options))
+                                     .to.be.rejected;
+    });
+    it('Registering succeeds. Huzzah!', () => {
+      mockRegisteringSucceeds();
+      return expect(EddystoneChromeOS.registerAdvertisement(valid_options))
+                                     .to.eventually.have.all.keys(
+                                       'id', 'url', 'txPower', 'type');
+    });
+    describe('Unsupported frame types', () => {
+      it('undefined', () => {
+        return expect(EddystoneChromeOS.registerAdvertisement({}))
+                                       .to.be.rejectedWith(Error);
+      });
+      it('uid', () => {
+        return expect(EddystoneChromeOS.registerAdvertisement({type: 'uid'}))
+                                       .to.be.rejectedWith(Error);
+      });
+      it('tlm', () => {
+        return expect(EddystoneChromeOS.registerAdvertisement({type: 'tlm'}))
+                                       .to.be.rejectedWith(Error);
+      });
+    });
+  });
+});

--- a/libraries/eddystone-advertising-library/test/setup/chrome-os.js
+++ b/libraries/eddystone-advertising-library/test/setup/chrome-os.js
@@ -1,4 +1,55 @@
-// Since we are simulating a browser:
-var window = {}; // jshint ignore: line
+// jshint ignore:start
 // TextEncoder is a Web API so we use the text-encoding polyfill.
-var TextEncoder = require('text-encoding').TextEncoder; // jshint ignore: line
+var TextEncoder = require('text-encoding').TextEncoder;
+var sinon = require('sinon');
+// Since we are simulating a browser:
+var window = global;
+// jshint ignore:end
+
+// Helper functions to mock the bluetoothLowEnergy API.
+(() => {
+  'use strict';
+  // Keep track of whether chrome is clean or not.
+  let _clean = false;
+
+  // This method cleans the `chrome` mock object so that
+  // a test can clean up after modifying it.
+  global.cleanChromeMock = function() {
+  // `chrome` is the object to expose APIs to Chrome Apps.
+    global.chrome = {
+      bluetoothLowEnergy: {},
+      runtime: {}
+    };
+    _clean = true;
+  };
+
+  // This method sets up `chrome` mock so registering a BLE advertisment fails.
+  global.mockRegisteringFailsWithMessage = function() {
+    _checkCleanChromeMock();
+    _clean = false;
+
+    let fail_to_register = sinon.stub();
+    fail_to_register.onFirstCall().callsArgAsync(1);
+    fail_to_register.throws(new Error('This stub should only be used once.'));
+    chrome.bluetoothLowEnergy.registerAdvertisement = fail_to_register;
+
+    chrome.runtime.lastError = {message: 'Failed to register advertisement.'};
+  };
+
+  // This method sets up `chrome` mock so that registering a BLE advertisement
+  // succeeds.
+  global.mockRegisteringSucceeds = function() {
+    _checkCleanChromeMock();
+    _clean = false;
+    let register = sinon.stub();
+    register.onFirstCall().callsArgWithAsync(1);
+    chrome.bluetoothLowEnergy.registerAdvertisement = register;
+  };
+
+  function _checkCleanChromeMock() {
+    if (!_clean) {
+      throw new Error('Need to clean chrome before starting another test.');
+    }
+  }
+})();
+cleanChromeMock();


### PR DESCRIPTION
Adds:
* `EddystoneChromeOS`: Class to wrap the underlying API
* `EddystoneAdvertisement`: Class that hols information about the Advertisement
* Moar docs
* Moar tests